### PR TITLE
Explicit EVM target version

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,7 @@ remappings = [
   "forge-std/=lib/forge-std/src/"
 ]
 verbosity = 1
+evm_version = "london"
 
 # Extreme Fuzzing CI Profile :P
 [profile.ci]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,7 +13,8 @@ const config: HardhatUserConfig = {
         enabled: true,
         runs: 200,
       },
-    },
+      evmVersion: "london"
+    }
   },
   networks: {
     scrollTestnet: {


### PR DESCRIPTION
Added `london` as explicit EVM target version for Hardhat and Foundry configs.
 
As of Solidity 0.8.20, `shanghai` will be the default target version with support for `PUSH0` opcode. More details [here](https://blog.soliditylang.org/2023/05/10/solidity-0.8.20-release-announcement/).