### PR TITLE
 Update RPC and Block Explorer URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1
+PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1  # Replace with your private key
 # SCROLL_TESTNET_URL=https://prealpha-rpc.scroll.io/l2 - Uncomment this line to use the pre-alpha instead of alpha
-SCROLL_TESTNET_URL=https://alpha-rpc.scroll.io/l2
+# SCROLL_TESTNET_URL=https://alpha-rpc.scroll.io/l2 - Uncomment this line to use the alpha instead of Sepolia
+SCROLL_TESTNET_URL=https://sepolia-rpc.scroll.io/ 
+SCROLL_MAINNET_URL=https://rpc.scroll.io/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project demonstrates how to use hardhat or foundry to deploy a contract in 
 2. Run `yarn install` to install dependencies.
 3. Create a `.env` file following the example `.env.example` in the root directory. Change `PRIVATE_KEY` to your own account private key in the `.env`.
 4. Run `yarn compile` to compile the contract.
-5. Run `yarn deploy:scrollTestnet` to deploy the contract on the Scroll Alpha Testnet.
+5. Run `yarn deploy:scrollTestnet` to deploy the contract on the Scroll Sepolia Testnet.
 6. Run `yarn test` for hardhat tests.
 
 
@@ -31,7 +31,7 @@ This project demonstrates how to use hardhat or foundry to deploy a contract in 
     ```
 3. Deploy the contract.
     ```
-    forge create --rpc-url https://alpha-rpc.scroll.io/l2 \
+    forge create --rpc-url https://sepolia-rpc.scroll.io \
       --value <lock_amount> \
       --constructor-args <unlock_time> \
       --private-key <your_private_key> \
@@ -43,7 +43,7 @@ This project demonstrates how to use hardhat or foundry to deploy a contract in 
   
   For example:
   ```
-  forge create --rpc-url https://alpha-rpc.scroll.io/l2 \
+  forge create --rpc-url https://sepolia-rpc.scroll.io \
     --value 0.00000000002ether \
     --constructor-args 1696118400 \
     --private-key 0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1 \

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -22,6 +22,12 @@ const config: HardhatUserConfig = {
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
     },
+    scrollMainnet: {
+      url: process.env.SCROLL_MAINNET_URL || "",
+      chainId: 534352,
+      accounts:
+        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+    },
   },
 };
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -14,7 +14,9 @@ async function main() {
 
   console.log(`Lock with 0.00000001 ETH and unlock timestamp ${unlockTime} deployed to ${lock.address}`);
   // console.log(`Block explorer URL: https://l2scan.scroll.io/address/${lock.address}`); Uncomment here to use the pre-alpha
-  console.log(`Block explorer URL: https://blockscout.scroll.io/address/${lock.address}`);
+  // console.log(`Block explorer URL: https://blockscout.scroll.io/address/${lock.address}`); Uncomment here to use the alpha
+  console.log(`Block explorer URL: https://sepolia.scrollscan.com/address/${lock.address}`); // Sepolia block explorer
+  // console.log(`Block explorer URL: https://scrollscan.com//address/${lock.address}`); // Mainnet block explorer
 }
 
 // We recommend this pattern to be able to use async/await everywhere


### PR DESCRIPTION

This PR updates the RPC and Block Explorer URLs for Scroll Network. These changes reflect the recent configuration changes in Scroll Network.

Changes:
- The RPC URL has been updated from the Alpha testnet to the Sepolia testnet.
- The Mainnet RPC URL has been added.
- The Testnet Block Explorer URL has been updated from "https://blockscout.scroll.io" to "https://sepolia.scrollscan.com".
- The Mainnet Block Explorer URL, "https://scrollscan.com/", has been added.
- README.md file has been updated

These changes are necessary to keep up with the recent configuration updates in Scroll Network. They ensure that the application interacts correctly with the network.

Tests:
The changes have been manually tested to confirm compatibility with the new configuration of Scroll Network. The tests involved making requests to the updated URLs and verifying the responses. The application's functionality was also tested to ensure it operates correctly with the new URLs.