### PR TITLE
Update Discord invite link on the readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ This project demonstrates how to use hardhat or foundry to deploy a contract in 
   
 ## Support
 
-Join our Discord: https://scroll.io/
+Join our Discord: https://discord.com/invite/scroll


### PR DESCRIPTION
Attempt to change the Discord invite link to https://discord.com/invite/scroll