### PR TITLE
Add NatSpec comments for Lock.sol contract clarity and documentation

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -1,12 +1,25 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
+/**
+ * @title Lock
+ * @dev This contract allows locking funds until a specified time, after which the owner can withdraw them.
+ */
 contract Lock {
-    uint public unlockTime;
-    address payable public owner;
+    uint public unlockTime; // The timestamp when the contract unlocks and funds can be withdrawn
+    address payable public owner; // The address that deployed the contract and can withdraw funds
 
+    /**
+     * @dev Emitted when funds are withdrawn from the contract.
+     * @param amount The amount of funds withdrawn.
+     * @param when The timestamp when the withdrawal occurred.
+     */
     event Withdrawal(uint amount, uint when);
 
+    /**
+     * @dev Constructor function that initializes the contract.
+     * @param _unlockTime The timestamp when funds can be withdrawn.
+     */
     constructor(uint _unlockTime) payable {
         require(
             block.timestamp < _unlockTime,
@@ -17,6 +30,9 @@ contract Lock {
         owner = payable(msg.sender);
     }
 
+    /**
+     * @dev Allows the owner to withdraw funds after the unlock time has passed.
+     */
     function withdraw() public {
         require(block.timestamp >= unlockTime, "You can't withdraw yet");
         require(msg.sender == owner, "You aren't the owner");


### PR DESCRIPTION
This commit adds NatSpec comments to the Solidity contract Lock for improved readability, clarity, and documentation. NatSpec comments follow best practices for Solidity documentation, providing explanations for the purpose of the contract, variables, events, and functions. These comments enhance the contract's understanding and maintainability for developers interacting with the codebase.